### PR TITLE
0920-contact-us-fix route join us form to job portal thank you page

### DIFF
--- a/src/app/apply-form-salesforce/apply-form-salesforce.component.ts
+++ b/src/app/apply-form-salesforce/apply-form-salesforce.component.ts
@@ -164,7 +164,7 @@ export class ApplyFormSalesforceComponent implements OnInit {
           requestParams = {
             oid: '00Df4000004JCvU',
             retURL: 'http://',
-            '00N5G00000VGNrS': 'Contact Us',
+            lead_source: 'Contact Us',
             country: 'United States',
             first_name: this.toTitleCase(this.form.value.firstName.trim()),
             last_name: this.toTitleCase(this.form.value.lastName.trim()),
@@ -180,7 +180,7 @@ export class ApplyFormSalesforceComponent implements OnInit {
           requestParams = {
             oid: '00Df4000004JCvU',
             retURL: 'http://',
-            '00N5G00000VGNrS': 'Contact Us',
+            lead_source: 'Contact Us',
             country: 'United States',
             first_name: this.toTitleCase(this.form.value.firstName.trim()),
             last_name: this.toTitleCase(this.form.value.lastName.trim()),

--- a/src/app/apply-form/apply-form.component.ts
+++ b/src/app/apply-form/apply-form.component.ts
@@ -505,27 +505,23 @@ export class ApplyFormComponent implements OnInit {
   }
 
   private applyOnSuccess(res: any): void {
-    if (this.isContactUs) {
-      window.location.href = 'https://smoothstack.com/contact-smoothstack/thank-you-build-your-team/';
-    } else {
-      let toastOptions: any = {
-        theme: 'success',
-        icon: 'check',
-        title: TranslateService.translate('THANK_YOU'),
-        message: TranslateService.translate('YOU_WILL_BE_CONTACTED'),
-        position: 'growlTopRight',
-        hideDelay: 3000,
-      };
-      this.toaster.alert(toastOptions);
-      this.storehasApplied();
-      this.applying = false;
-      const state = {
-        jobTitle: this.job.title,
-        schedulingLink: res.schedulingLink,
-        challengeInfo: this.job.customTextBlock1,
-      };
-      this.router.navigate(['/jobs/success/'], { state });
-    }
+    let toastOptions: any = {
+      theme: 'success',
+      icon: 'check',
+      title: TranslateService.translate('THANK_YOU'),
+      message: TranslateService.translate('YOU_WILL_BE_CONTACTED'),
+      position: 'growlTopRight',
+      hideDelay: 3000,
+    };
+    this.toaster.alert(toastOptions);
+    this.storehasApplied();
+    this.applying = false;
+    const state = {
+      jobTitle: this.job.title,
+      schedulingLink: res.schedulingLink,
+      challengeInfo: this.job.customTextBlock1,
+    };
+    this.router.navigate(['/jobs/success/'], { state });
   }
 
   private applyOnFailure(res: any): void {

--- a/src/app/utils/apply-form-overwrite.component.scss
+++ b/src/app/utils/apply-form-overwrite.component.scss
@@ -16,11 +16,12 @@
         }
         novo-control.tiles {
             label.novo-control-label {
-            width: auto !important;
-            transform: translateY(-125%) !important;
-            white-space: normal !important;
-            overflow-x: visible !important;
-            color:#606060 !important; // form field label color
+                width: auto !important;
+                transform: translateY(-125%) !important;
+                white-space: normal !important;
+                overflow-x: visible !important;
+                color:#606060 !important; // form field label color
+                padding-bottom: 27px !important;
             }
         }
     


### PR DESCRIPTION
This PR is to 
1. reroute the submission page for Join Our Team form on the contact page to job-portal's thank you page instead of WP's thank you page.
2. Update web-to-lead field name for contact us SF form
3. Update apply form overwrite to increase title padding